### PR TITLE
Feature/stats

### DIFF
--- a/delix.conf.toml
+++ b/delix.conf.toml
@@ -9,3 +9,6 @@ public_address = "127.0.0.1:4001"
 local_address = "127.0.0.1:4001"
 request_timeout_ms = 500
 balancer = { type = "dynamic_round_robin" }
+
+[stats]
+collectors = ["debug"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,4 @@ pub mod discovery;
 pub mod message;
 pub mod node;
 pub mod transport;
+pub mod stats;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -25,7 +25,9 @@ use delix::discovery::Discovery;
 use delix::transport::Transport;
 use delix::transport::Direct;
 use delix::transport::direct::{Balancer, balancer};
-use delix::stats::NullStatCollector;
+use delix::stats::MultiStatCollector;
+use delix::stats::DebugStatCollector;
+use delix::stats::StatCollector;
 use configuration::Configuration;
 
 #[derive(Debug)]
@@ -64,6 +66,18 @@ impl Loader {
             _ => return Err(Error::UnknownDiscoveryType(discovery_type)),
         };
 
+        let stat_collectors: Vec<Box<StatCollector>> = configuration.strings_at("stats.collectors")
+            .unwrap_or(vec![])
+            .iter()
+            .filter_map(|c| -> Option<Box<StatCollector>> {
+                match c.as_ref() {
+                    "debug" => Some(Box::new(DebugStatCollector)),
+                    _ => None,
+                }})
+            .collect();
+
+        let stat_collector = Box::new(MultiStatCollector::new(stat_collectors));
+
         let transport_type = match configuration.string_at("transport.type") {
             Some(transport_type) => transport_type,
             None => return Err(Error::NoTransportType),
@@ -92,7 +106,7 @@ impl Loader {
                     _ => return Err(Error::UnknownBalancerType(balancer_type)),
                 };
 
-                Box::new(Direct::new(balancer, local_address, public_address, request_timeout, Box::new(NullStatCollector::new()))
+                Box::new(Direct::new(balancer, local_address, public_address, request_timeout, stat_collector))
             }
             _ => return Err(Error::UnknownTransportType(transport_type)),
         };

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -25,6 +25,7 @@ use delix::discovery::Discovery;
 use delix::transport::Transport;
 use delix::transport::Direct;
 use delix::transport::direct::{Balancer, balancer};
+use delix::stats::NullStatCollector;
 use configuration::Configuration;
 
 #[derive(Debug)]
@@ -91,7 +92,7 @@ impl Loader {
                     _ => return Err(Error::UnknownBalancerType(balancer_type)),
                 };
 
-                Box::new(Direct::new(balancer, local_address, public_address, request_timeout))
+                Box::new(Direct::new(balancer, local_address, public_address, request_timeout, Box::new(NullStatCollector::new()))
             }
             _ => return Err(Error::UnknownTransportType(transport_type)),
         };

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -23,9 +23,9 @@ pub trait StatCollector : Send + Sync {
     fn decrement(&self, path: &[&str]);
 }
 
-pub struct LoggingStatCollector;
+pub struct DebugStatCollector;
 
-impl StatCollector for LoggingStatCollector {
+impl StatCollector for DebugStatCollector {
     fn increment(&self, path: &[&str]) {
         println!("incrementing stat {}", path.join("."));
     }
@@ -37,22 +37,22 @@ impl StatCollector for LoggingStatCollector {
 
 pub struct NullStatCollector;
 
-impl NullStatCollector {
-    pub fn new() -> NullStatCollector {
-        NullStatCollector
+impl StatCollector for NullStatCollector {
+    fn increment(&self, _path: &[&str]) {}
+    fn decrement(&self, _path: &[&str]) {}
+}
+
+pub struct MultiStatCollector {
+    collectors: Vec<Box<StatCollector>>,
+}
+
+impl MultiStatCollector {
+    pub fn new(cs: Vec<Box<StatCollector>>) -> MultiStatCollector {
+        return MultiStatCollector { collectors: cs };
     }
 }
 
-impl StatCollector for NullStatCollector {
-    fn increment(&self, path: &[&str]) {}
-    fn decrement(&self, path: &[&str]) {}
-}
-
-pub struct MultiStatCollector<'a> {
-    collectors: Vec<Box<StatCollector + 'a>>,
-}
-
-impl<'a> StatCollector for MultiStatCollector<'a> {
+impl StatCollector for MultiStatCollector {
     fn increment(&self, path: &[&str]) {
         for c in &self.collectors {
             c.increment(path);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,67 @@
+// Copyright 2015 The Delix Project Authors. See the AUTHORS file at the top level directory.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// `path` arguments are always slices comprising the identity of some counter,
+/// with segments appearing in order of increasing specificity,
+/// e.g. `&["handshakes", "Billy", "Tuesday"]`.
+pub trait StatCollector : Send + Sync {
+    // Increment the described counter by 1
+    fn increment(&self, path: &[&str]);
+    // Decrement the described counter by 1
+    fn decrement(&self, path: &[&str]);
+}
+
+pub struct LoggingStatCollector;
+
+impl StatCollector for LoggingStatCollector {
+    fn increment(&self, path: &[&str]) {
+        println!("incrementing stat {}", path.join("."));
+    }
+
+    fn decrement(&self, path: &[&str]) {
+        println!("decrementing stat {}", path.join("."));
+    }
+}
+
+pub struct NullStatCollector;
+
+impl NullStatCollector {
+    pub fn new() -> NullStatCollector {
+        NullStatCollector
+    }
+}
+
+impl StatCollector for NullStatCollector {
+    fn increment(&self, path: &[&str]) {}
+    fn decrement(&self, path: &[&str]) {}
+}
+
+pub struct MultiStatCollector<'a> {
+    collectors: Vec<Box<StatCollector + 'a>>,
+}
+
+impl<'a> StatCollector for MultiStatCollector<'a> {
+    fn increment(&self, path: &[&str]) {
+        for c in &self.collectors {
+            c.increment(path);
+        }
+    }
+
+    fn decrement(&self, path: &[&str]) {
+        for c in &self.collectors {
+            c.decrement(path);
+        }
+    }
+}

--- a/tests/configurations/one.conf.toml
+++ b/tests/configurations/one.conf.toml
@@ -8,3 +8,6 @@ type = "direct"
 local_address = "127.0.0.1:4001"
 request_timeout_ms = 500
 balancer = { type = "dynamic_round_robin" }
+
+[stats]
+collectors = ["debug"]

--- a/tests/configurations/two.conf.toml
+++ b/tests/configurations/two.conf.toml
@@ -8,3 +8,6 @@ type = "direct"
 local_address = "127.0.0.1:4002"
 request_timeout_ms = 500
 balancer = { type = "dynamic_round_robin" }
+
+[stats]
+collectors = ["debug"]

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -21,6 +21,7 @@ use delix::discovery::Constant;
 use delix::node::{Node, State};
 use delix::transport::Direct;
 use delix::transport::direct::balancer;
+use delix::stats::NullStatCollector;
 
 pub fn build_node(local_address: &str, discover_addresses: &[&str]) -> Node {
     let balancer = Box::new(balancer::DynamicRoundRobin::new());
@@ -30,10 +31,12 @@ pub fn build_node(local_address: &str, discover_addresses: &[&str]) -> Node {
                                                                  s.parse::<SocketAddr>().unwrap()
                                                              })
                                                              .collect()));
+<<<<<<< HEAD
     let transport = Box::new(Direct::new(balancer,
                                          local_address.parse::<SocketAddr>().unwrap(),
                                          None,
-                                         None));
+                                         None,
+                                         Box::new(NullStatCollector::new())));
     Node::new(discovery, transport).unwrap()
 }
 

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -30,13 +30,13 @@ pub fn build_node(local_address: &str, discover_addresses: &[&str]) -> Node {
                                                              .map(|s| {
                                                                  s.parse::<SocketAddr>().unwrap()
                                                              })
-                                                             .collect()));
-<<<<<<< HEAD
+                                           .collect()));
+
     let transport = Box::new(Direct::new(balancer,
                                          local_address.parse::<SocketAddr>().unwrap(),
                                          None,
                                          None,
-                                         Box::new(NullStatCollector::new())));
+                                         Box::new(NullStatCollector)));
     Node::new(discovery, transport).unwrap()
 }
 


### PR DESCRIPTION
This isn't an impressive set of functionality, but this is all new enough to me that I wanted feedback as early on as is practical. 

The general idea was to start out w/ something stupidly simple which could be grown into implementations e.g. keeping state for display via some custom web UI, or sending stuff to statsd - as suggested.
- You'll note this is missing any calls to `decrement` - how do you think this ought to work, in, e.g. `Direct`?  One approach would be to keep the stat emission inside `Direct`, modify `Connection.set_on_shutdown` to be a guy which can accept multiple callbacks, and have `Direct` set a callback on the connection itself, which calls decrement.  A simpler alternative would be to pass the stat object to `Connection`, and have it call decrement itself, in its shutdown handler.  The increment calls could potentially go there also.
- The stuff in `loader.rs` will silently ignore strings which don't refer to legitimate stat collectors.  What I wanted was to have `stat_collectors` be a `Result<Vec<Box<StatCollector>>`, and somehown turn an iterable of `Result<Box<StatCollector>>`, into either a vector of unwrapped values, or an error representing the first error in the iterable.  But I wasn't sure how best to do this.

Please be as aggressive as you have time for, in your feedback.
